### PR TITLE
Use underscores instead of hyphens for phrasal verbs

### DIFF
--- a/verbnet3.3/adopt-93.xml
+++ b/verbnet3.3/adopt-93.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE VNCLASS SYSTEM "vn_class-3.dtd">
 <VNCLASS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="adopt-93" xsi:noNamespaceSchemaLocation="vn_schema-3.xsd">
     <MEMBERS>
-        <MEMBER name="abide-by" wn="abide_by%2:41:00" grouping="abide.03"/>
+        <MEMBER name="abide_by" wn="abide_by%2:41:00" grouping="abide.03"/>
         <MEMBER name="assume" wn="assume%2:41:00 assume%2:30:00 assume%2:38:00" grouping="assume.02"/>
         <MEMBER name="adopt" wn="adopt%2:40:02" grouping="adopt.01"/>
         <MEMBER name="follow" wn="follow%2:41:00 follow%2:40:00" grouping="follow.03"/>

--- a/verbnet3.3/banish-10.2.xml
+++ b/verbnet3.3/banish-10.2.xml
@@ -11,9 +11,9 @@
         <MEMBER name="recuse" wn="recuse%2:32:00" grouping=""/>
         <MEMBER name="remove" wn="remove%2:30:00 remove%2:41:00 remove%2:40:00 remove%2:41:02 remove%2:38:00" grouping="remove.01"/>
         <MEMBER name="shanghai" wn="shanghai%2:35:00" grouping=""/>
-        <MEMBER name="turn-away" wn="" grouping=""/>
-        <MEMBER name="turn-back" wn="" grouping=""/>
-        <MEMBER name="turn-out" wn="" grouping=""/>
+        <MEMBER name="turn_away" wn="" grouping=""/>
+        <MEMBER name="turn_back" wn="" grouping=""/>
+        <MEMBER name="turn_out" wn="" grouping=""/>
         <MEMBER name="boot" wn="boot%2:35:00" grouping="boot.03"/>
     </MEMBERS>
     <THEMROLES>

--- a/verbnet3.3/calibratable_cos-45.6.1.xml
+++ b/verbnet3.3/calibratable_cos-45.6.1.xml
@@ -158,7 +158,7 @@
                 <MEMBER name="explode" wn="explode%2:30:02" grouping="explode.03" features="+increase"/>
                 <MEMBER name="fall" wn="fall%2:30:06" grouping="fall.04" features="+decrease"/>
                 <MEMBER name="fall_away" wn="fall_away%2:30:00" grouping="fall.02" features="+decrease"/>
-                <MEMBER name="fall-off" wn="" grouping="" features="+decrease"/>
+                <MEMBER name="fall_off" wn="" grouping="" features="+decrease"/>
                 <MEMBER name="fluctuate" wn="fluctuate%2:30:00" grouping="fluctuate.01" features="+fluctuate"/>
                 <MEMBER name="gain" wn="gain%2:30:00" grouping="gain.02" features="+increase"/>
                 <MEMBER name="go_down" wn="go_down%2:30:00" grouping="go.02" features="+decrease"/>

--- a/verbnet3.3/caused_calibratable_cos-45.6.2.xml
+++ b/verbnet3.3/caused_calibratable_cos-45.6.2.xml
@@ -164,7 +164,7 @@
             <MEMBERS>
                 <MEMBER name="advance" wn="" grouping=""/>
                 <MEMBER name="balloon" wn="" grouping="balloon.01 balloon.02"/>
-                <MEMBER name="build-up" wn="" grouping=""/>
+                <MEMBER name="build_up" wn="" grouping=""/>
                 <MEMBER name="decrease" wn="" grouping="decrease.01"/>
                 <MEMBER name="diminish" wn="" grouping="diminish.01"/>
                 <MEMBER name="increase" wn="" grouping="increase.01"/>

--- a/verbnet3.3/complete-55.2.xml
+++ b/verbnet3.3/complete-55.2.xml
@@ -3,8 +3,8 @@
     <MEMBERS>
         <MEMBER name="accomplish" wn="accomplish%2:36:00 accomplish%2:41:00" grouping="accomplish.01"/>
         <MEMBER name="achieve" wn="achieve%2:41:00" grouping="achieve.01"/>
-        <MEMBER name="bring-off" wn="" grouping="bring.08"/>
-        <MEMBER name="pull-off" wn="" grouping="pull.04"/>
+        <MEMBER name="bring_off" wn="" grouping="bring.08"/>
+        <MEMBER name="pull_off" wn="" grouping="pull.04"/>
     </MEMBERS>
     <THEMROLES>
         <THEMROLE type="Agent">

--- a/verbnet3.3/contribute-13.2.xml
+++ b/verbnet3.3/contribute-13.2.xml
@@ -9,15 +9,15 @@
         <MEMBER name="resign" wn="" grouping=""/>
         <MEMBER name="restore" wn="restore%2:40:00" grouping="restore.02"/>
         <MEMBER name="gift" wn="gift%2:40:00" grouping="gift.02"/>
-        <MEMBER name="give-away" wn="" grouping="give.01 give.02"/> 
-        <MEMBER name="give-out" wn="" grouping="give.01 give.02"/>
-        <MEMBER name="give-up" wn="" grouping="give.01 give.02"/>
+        <MEMBER name="give_away" wn="" grouping="give.01 give.02"/>
+        <MEMBER name="give_out" wn="" grouping="give.01 give.02"/>
+        <MEMBER name="give_up" wn="" grouping="give.01 give.02"/>
         <MEMBER name="hand_out" wn="hand_out%2:40:00" grouping=""/>
         <MEMBER name="pass_out" wn="pass_out%2:40:00" grouping=""/>
         <MEMBER name="shell_out" wn="shell_out%2:40:00" grouping=""/>
         <MEMBER name="abnegate" wn="abnegate%2:33:00" grouping=""/>
-        <MEMBER name="turn-in" wn="" grouping=""/>
-        <MEMBER name="turn-over" wn="" grouping=""/>
+        <MEMBER name="turn_in" wn="" grouping=""/>
+        <MEMBER name="turn_over" wn="" grouping=""/>
     </MEMBERS>
     <THEMROLES>
         <THEMROLE type="Agent">

--- a/verbnet3.3/create-26.4.xml
+++ b/verbnet3.3/create-26.4.xml
@@ -26,7 +26,7 @@
         <MEMBER name="reorganize" wn="reorganize%2:41:00 reorganize%2:41:01" grouping="reorganize.01"/>
         <MEMBER name="style" wn="style%2:36:00" grouping="style.01"/>
         <MEMBER name="synthesize" wn="synthesize%2:31:00" grouping="synthesize.01"/>
-        <MEMBER name="turn-out" wn="" grouping=""/>
+        <MEMBER name="turn_out" wn="" grouping=""/>
     </MEMBERS>
     <THEMROLES>
         <THEMROLE type="Agent">

--- a/verbnet3.3/engender-27.1.xml
+++ b/verbnet3.3/engender-27.1.xml
@@ -11,7 +11,7 @@
         <MEMBER name="produce" wn="produce%2:36:03" grouping="produce.01"/>
         <MEMBER name="raise" wn="raise%2:32:00 raise%2:36:06 raise%2:32:06" grouping="raise.03"/> 
         <MEMBER name="return" wn="return%2:36:00" grouping="return.02"/>
-        <MEMBER name="set-in_motion" wn="set_in_motion%2:35:05" grouping="set.06"/>
+        <MEMBER name="set_in_motion" wn="set_in_motion%2:35:05" grouping="set.06"/>
         <MEMBER name="set_off" wn="set_off%2:32:00 set_off%2:36:00" grouping=""/>
         <MEMBER name="shape" wn="shape%2:31:00" grouping="shape.02"/>
         <MEMBER name="sire" wn="" grouping=""/>

--- a/verbnet3.3/future_having-13.3.xml
+++ b/verbnet3.3/future_having-13.3.xml
@@ -3,7 +3,7 @@
     <MEMBERS>
 	<MEMBER name="accord" wn="accord%2:40:00" grouping=""/>
 	<MEMBER name="devolve" wn="devolve%2:41:02" grouping="devolve.01"/>		
-	<MEMBER name="portion-out" wn="portion%2:40:00" grouping=""/>
+	<MEMBER name="portion_out" wn="portion%2:40:00" grouping=""/>
 	<MEMBER name="ration" wn="ration%2:40:00" grouping=""/>
     </MEMBERS>
     <THEMROLES>

--- a/verbnet3.3/give-13.1.xml
+++ b/verbnet3.3/give-13.1.xml
@@ -2,7 +2,7 @@
 <VNCLASS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="give-13.1" xsi:noNamespaceSchemaLocation="vn_schema-3.xsd">
     <MEMBERS>
         <MEMBER name="deal" wn="deal%2:40:01 deal%2:40:02 deal%2:40:07         deal%2:40:06" grouping="deal.04"/>
-        <MEMBER name="give-back" wn="" grouping="give.01 give.02"/>
+        <MEMBER name="give_back" wn="" grouping="give.01 give.02"/>
         <MEMBER name="lend" wn="lend%2:40:00" grouping="lend.02"/>
         <MEMBER name="loan" wn="loan%2:40:00" grouping=""/>
         <MEMBER name="pass" wn="pass%2:40:00 pass%2:40:01 pass%2:40:13 pass%2:38:04" grouping="pass.04"/>

--- a/verbnet3.3/interact-36.6.xml
+++ b/verbnet3.3/interact-36.6.xml
@@ -1,13 +1,13 @@
 <!DOCTYPE VNCLASS SYSTEM "vn_class-3.dtd">
 <VNCLASS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="interact-36.6" xsi:noNamespaceSchemaLocation="vn_schema-3.xsd">
     <MEMBERS>
-        <MEMBER name="follow-up" wn="" grouping="follow.06"/>
-        <MEMBER name="follow-through" wn="" grouping="follow.06"/>
-        <MEMBER name="go-steady" wn="go_steady%2:41:00" grouping=""/>
-        <MEMBER name="go-out" wn="go_out%2:41:00" grouping=""/>
+        <MEMBER name="follow_up" wn="" grouping="follow.06"/>
+        <MEMBER name="follow_through" wn="" grouping="follow.06"/>
+        <MEMBER name="go_steady" wn="go_steady%2:41:00" grouping=""/>
+        <MEMBER name="go_out" wn="go_out%2:41:00" grouping=""/>
         <MEMBER name="interact" wn="interact%2:41:00" grouping=""/>
-        <MEMBER name="hook-up" wn="" grouping="hook.04"/>
-        <MEMBER name="split-up" wn="split_up%2:41:01" grouping="split.03"/>
+        <MEMBER name="hook_up" wn="" grouping="hook.04"/>
+        <MEMBER name="split_up" wn="split_up%2:41:01" grouping="split.03"/>
     </MEMBERS>
     <THEMROLES>
         <THEMROLE type="Agent">

--- a/verbnet3.3/murder-42.1.xml
+++ b/verbnet3.3/murder-42.1.xml
@@ -160,7 +160,7 @@
         <VNSUBCLASS ID="murder-42.1-1">
             <MEMBERS>
                 <MEMBER name="kill" wn="kill%2:35:00 kill%2:35:01                 kill%2:42:00 kill%2:35:02" grouping="kill.01"/>
-                <MEMBER name="kill-off" wn="kill_off%2:35:00" grouping="kill.01"/>      
+                <MEMBER name="kill_off" wn="kill_off%2:35:00" grouping="kill.01"/>
             </MEMBERS>
             <THEMROLES>
                 <THEMROLE type="Instrument">

--- a/verbnet3.3/other_cos-45.4.xml
+++ b/verbnet3.3/other_cos-45.4.xml
@@ -312,8 +312,8 @@
         <MEMBER name="treble" wn="" grouping=""/>
         <MEMBER name="trip" wn="trip%2:36:00" grouping="trip.03"/>
         <MEMBER name="triple" wn="triple%2:30:00" grouping="triple.01"/>
-        <MEMBER name="turn-on" wn="" grouping=""/>
-        <MEMBER name="turn-off" wn="" grouping=""/>
+        <MEMBER name="turn_on" wn="" grouping=""/>
+        <MEMBER name="turn_off" wn="" grouping=""/>
         <MEMBER name="ulcerate" wn="ulcerate%2:30:00 ulcerate%2:29:00" grouping=""/>
         <MEMBER name="unionize" wn="unionize%2:41:00" grouping=""/>
 	<MEMBER name="upload" wn="" grouping=""/>

--- a/verbnet3.3/put-9.1.xml
+++ b/verbnet3.3/put-9.1.xml
@@ -155,7 +155,7 @@
             <MEMBERS>
                 <MEMBER name="apply" wn="apply%2:35:00" grouping="apply.03"/>
                 <MEMBER name="bury" wn="bury%2:39:00 bury%2:41:00                 bury%2:35:00 bury%2:35:02 bury%2:35:01" grouping="bury.01                 bury.02"/>
-                <MEMBER name="build-in" wn="build_in%2:30:00" grouping="build.05"/>
+                <MEMBER name="build_in" wn="build_in%2:30:00" grouping="build.05"/>
                 <MEMBER name="deposit" wn="deposit%2:40:00" grouping="deposit.02"/>
                 <MEMBER name="embed" wn="embed%2:35:00" grouping="embed.01"/>
                 <MEMBER name="insert" wn="insert%2:35:00" grouping="insert.01"/>

--- a/verbnet3.3/reject-77.2.xml
+++ b/verbnet3.3/reject-77.2.xml
@@ -4,7 +4,7 @@
 	<MEMBER name="decline" wn="" grouping=""/>
 	<MEMBER name="rebuff" wn="" grouping=""/>
 	<MEMBER name="refuse" wn="" grouping=""/>
-	<MEMBER name="turn-down" wn="" grouping=""/>
+	<MEMBER name="turn_down" wn="" grouping=""/>
     </MEMBERS>
     <THEMROLES>
         <THEMROLE type="Agent">

--- a/verbnet3.3/remedy-45.7.xml
+++ b/verbnet3.3/remedy-45.7.xml
@@ -15,8 +15,8 @@
         <MEMBER name="bloody" wn="" grouping=""/>
         <MEMBER name="botch" wn="" grouping=""/>
         <MEMBER name="bowdlerize" wn="" grouping=""/>
-        <MEMBER name="bring-out" wn="" grouping=""/>
-        <MEMBER name="bring-up" wn="" grouping=""/>		
+        <MEMBER name="bring_out" wn="" grouping=""/>
+        <MEMBER name="bring_up" wn="" grouping=""/>
         <MEMBER name="bungle" wn="" grouping=""/>
         <MEMBER name="capacitate" wn="" grouping="capacitate.01 capacitate.02"/>
         <MEMBER name="carbonify" wn="" grouping=""/>
@@ -145,8 +145,8 @@
         <MEMBER name="traumatize" wn="" grouping=""/>
         <MEMBER name="truncate" wn="" grouping=""/>
         <MEMBER name="trivialize" wn="trivialize%2:32:00" grouping=""/>
-        <MEMBER name="turn-up" wn="" grouping=""/>
-        <MEMBER name="turn-down" wn="" grouping=""/>
+        <MEMBER name="turn_up" wn="" grouping=""/>
+        <MEMBER name="turn_down" wn="" grouping=""/>
         <MEMBER name="underfeed" wn="" grouping=""/>
         <MEMBER name="urbanize" wn="" grouping=""/>
         <MEMBER name="ventilate" wn="" grouping=""/>

--- a/verbnet3.3/remove-10.1.xml
+++ b/verbnet3.3/remove-10.1.xml
@@ -4,7 +4,7 @@
         <MEMBER name="abolish" wn="abolish%2:41:00" grouping="abolish.01"/>
         <MEMBER name="abstract" wn="abstract%2:40:00" grouping="abstract.02"/>
         <MEMBER name="cull" wn="cull%2:40:00 cull%2:35:00" grouping=""/>
-        <MEMBER name="cut-off" wn="" grouping="cut.06"/>
+        <MEMBER name="cut_off" wn="" grouping="cut.06"/>
         <MEMBER name="deburr" wn="" grouping=""/>
         <MEMBER name="deduct" wn="deduct%2:31:01 deduct%2:40:00" grouping="deduct.01"/>
         <MEMBER name="delete" wn="delete%2:35:00 delete%2:32:00" grouping="delete.01"/>

--- a/verbnet3.3/support-15.3.xml
+++ b/verbnet3.3/support-15.3.xml
@@ -49,7 +49,7 @@
 		<MEMBER name="boost" wn="" grouping="boost.01 boost.02"/>
 		<MEMBER name="buttress" wn="" grouping=""/>
 		<MEMBER name="buoy" wn="" grouping="buoy.01"/>
-		<MEMBER name="hold-up" wn="" grouping="hold.03"/>
+		<MEMBER name="hold_up" wn="" grouping="hold.03"/>
 		<MEMBER name="reinforce" wn="" grouping="reinforce.01"/>
 		<MEMBER name="strengthen" wn="" grouping="strengthen.01"/>
 		<MEMBER name="support" wn="" grouping="support.01"/>


### PR DESCRIPTION
Just to improve consistency, since the majority of phrasal verbs in VN 3.3 use underscores instead of hyphens