### PR TITLE
Fixed 2 XML tag errors in rotate-51.9.1.xml

### DIFF
--- a/verbnet3.4/rotate-51.9.1.xml
+++ b/verbnet3.4/rotate-51.9.1.xml
@@ -113,7 +113,7 @@
     </NP>
     <PREP/>
     <NP value="Trajectory">
-     <SYNTRESTRS/>
+     <SYNRESTRS/>
     </NP>
    </SYNTAX>
    <SEMANTICS>
@@ -238,7 +238,7 @@
       </NP>
       <PREP/>
       <NP value="Trajectory">
-       <SYNTRESTRS/>
+       <SYNRESTRS/>
       </NP>
      </SYNTAX>
      <SEMANTICS>


### PR DESCRIPTION
rotate-51.9.1.xml
  Line 116: erroneous tag <SYNTRESTRS/>
	should be <SYNRESTRS/>
  Line 241: erroneous tag <SYNTRESTRS/>
	should be <SYNRESTRS/>