### PR TITLE
Fixed 2 either wrong or inconsistent XML tags in vehicle-51.4.1

### DIFF
--- a/verbnet3.4/vehicle-51.4.1.xml
+++ b/verbnet3.4/vehicle-51.4.1.xml
@@ -340,7 +340,7 @@
     <VERB />
     <NP value="Theme">
      <SYNRESTRS>
-      <SELRESTR Value="+" type="vehicle_part" />
+      <SYNRESTR Value="+" type="vehicle_part" />
      </SYNRESTRS>
     </NP>
     <NP value="Result">
@@ -445,7 +445,7 @@
     <VERB />
     <NP value="Theme">
      <SYNRESTRS>
-      <SELRESTR Value="+" type="vehicle_part" />
+      <SYNRESTR Value="+" type="vehicle_part" />
      </SYNRESTRS>
     </NP>
     <PREP value="to into">


### PR DESCRIPTION
CAUTION: please review - alternatively the enclosing tags should maybe be <SELRESTRS> instead of <SYNRESTRS>?

vehicle-51.4.1.xml:
  Line 343: erroneous <SELRESTR Value="+" type="vehicle_part" />
	within NP <SYNRESTRS> tags
	should be <SYNRESTR Value="+" type="vehicle_part" />?

  Line 448: erroneous <SELRESTR Value="+" type="vehicle_part" />
	within NP <SYNRESTRS> tags
	should be <SYNRESTR Value="+" type="vehicle_part" />?