### PR TITLE
fixed underspecified locations in semantics

### DIFF
--- a/verbnet3.4/accompany-51.7.xml
+++ b/verbnet3.4/accompany-51.7.xml
@@ -48,14 +48,14 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e2"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -69,7 +69,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -83,7 +83,7 @@
      <ARGS>
       <ARG type="Event" value="ë4"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="co-temporal">
@@ -137,14 +137,14 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e2"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -158,7 +158,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -172,7 +172,7 @@
      <ARGS>
       <ARG type="Event" value="ë4"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="co-temporal">

--- a/verbnet3.4/butter-9.9.xml
+++ b/verbnet3.4/butter-9.9.xml
@@ -179,7 +179,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="VerbSpecific" value="V_Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -199,7 +199,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="VerbSpecific" value="V_Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -245,7 +245,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -265,7 +265,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">

--- a/verbnet3.4/chase-51.6.xml
+++ b/verbnet3.4/chase-51.6.xml
@@ -47,14 +47,14 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e2"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -68,7 +68,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -82,7 +82,7 @@
      <ARGS>
       <ARG type="Event" value="ë4"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -130,14 +130,14 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e2"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -151,7 +151,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -165,7 +165,7 @@
      <ARGS>
       <ARG type="Event" value="ë4"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -208,14 +208,14 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e2"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -229,7 +229,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -243,7 +243,7 @@
      <ARGS>
       <ARG type="Event" value="ë4"/>
       <ARG type="ThemRole" value="Agent"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">

--- a/verbnet3.4/confine-92.xml
+++ b/verbnet3.4/confine-92.xml
@@ -49,7 +49,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED bool="!" value="confined">
@@ -75,14 +75,14 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
      <ARGS>
       <ARG type="Event" value="e4"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="ThemRole" value="?Destination"/>
+      <ARG type="ThemRole" value="Destination"/>
      </ARGS>
     </PRED>
     <PRED value="confined">
@@ -137,7 +137,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED bool="!" value="confined">
@@ -163,14 +163,14 @@
        <ARGS>
         <ARG type="Event" value="ë3"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">
        <ARGS>
         <ARG type="Event" value="e4"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="ThemRole" value="?Destination"/>
+        <ARG type="ThemRole" value="Destination"/>
        </ARGS>
       </PRED>
       <PRED value="confined">

--- a/verbnet3.4/pocket-9.10.xml
+++ b/verbnet3.4/pocket-9.10.xml
@@ -94,7 +94,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -114,7 +114,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -161,7 +161,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -181,7 +181,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -238,7 +238,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="motion">
@@ -252,7 +252,7 @@
        <ARGS>
         <ARG type="Event" value="ë2"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">
@@ -282,7 +282,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="motion">
@@ -296,7 +296,7 @@
        <ARGS>
         <ARG type="Event" value="ë2"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">
@@ -329,7 +329,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="motion">
@@ -343,7 +343,7 @@
        <ARGS>
         <ARG type="Event" value="ë2"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">

--- a/verbnet3.4/put-9.1.xml
+++ b/verbnet3.4/put-9.1.xml
@@ -64,7 +64,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -84,7 +84,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -130,7 +130,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -150,7 +150,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -209,7 +209,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme "/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="do">
@@ -229,7 +229,7 @@
        <ARGS>
         <ARG type="Event" value="ë3"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">
@@ -290,7 +290,7 @@
        <ARGS>
         <ARG type="Event" value="e1"/>
         <ARG type="ThemRole" value="Theme "/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="do">
@@ -310,7 +310,7 @@
        <ARGS>
         <ARG type="Event" value="ë3"/>
         <ARG type="ThemRole" value="Theme"/>
-        <ARG type="PredSpecific" value="Initial_Location"/>
+        <ARG type="PredSpecific" value="?Initial_Location"/>
        </ARGS>
       </PRED>
       <PRED value="has_location">

--- a/verbnet3.4/put_spatial-9.2.xml
+++ b/verbnet3.4/put_spatial-9.2.xml
@@ -81,7 +81,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -101,7 +101,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">
@@ -153,7 +153,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme "/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="do">
@@ -173,7 +173,7 @@
      <ARGS>
       <ARG type="Event" value="ë3"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">

--- a/verbnet3.4/reach-51.8.xml
+++ b/verbnet3.4/reach-51.8.xml
@@ -40,7 +40,7 @@
      <ARGS>
       <ARG type="Event" value="e1"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="motion">
@@ -54,7 +54,7 @@
      <ARGS>
       <ARG type="Event" value="ë2"/>
       <ARG type="ThemRole" value="Theme"/>
-      <ARG type="PredSpecific" value="Initial_Location"/>
+      <ARG type="PredSpecific" value="?Initial_Location"/>
      </ARGS>
     </PRED>
     <PRED value="has_location">


### PR DESCRIPTION
In rare cases, the '?' is missing in a frame's semantics. For example, if we look at "I put the book on/under/near the table." in put-9.1.xml, we can see that e1 has_location Initial_Location. This is incorrect as the book's initial location is not specified. My edit follows example (7) in Brown et al, 2022, "Semantic Representations for NLP Using VerbNet and the Generative Lexicon". The '?' is present in the paper (example 7). For ease, this paper can be found here: https://www.frontiersin.org/articles/10.3389/frai.2022.821697/full